### PR TITLE
Add SixthSense paper to homepage

### DIFF
--- a/images/SixthSense2026.svg
+++ b/images/SixthSense2026.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200" viewBox="0 0 320 200">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#102033"/>
+      <stop offset="1" stop-color="#23506d"/>
+    </linearGradient>
+    <radialGradient id="pulse" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#79d6ff" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#79d6ff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="320" height="200" rx="18" fill="url(#bg)"/>
+  <circle cx="160" cy="95" r="82" fill="url(#pulse)" opacity="0.45"/>
+  <g fill="none" stroke="#dff7ff" stroke-width="7" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="160" cy="48" r="16"/>
+    <path d="M160 65v45"/>
+    <path d="M124 87h72"/>
+    <path d="M160 110l-33 45"/>
+    <path d="M160 110l33 45"/>
+  </g>
+  <g stroke="#ffcf6e" stroke-width="5" stroke-linecap="round">
+    <path d="M72 57l35 22"/>
+    <path d="M248 57l-35 22"/>
+    <path d="M70 133l36-22"/>
+    <path d="M250 133l-36-22"/>
+  </g>
+  <g fill="#ffcf6e">
+    <circle cx="70" cy="57" r="8"/>
+    <circle cx="250" cy="57" r="8"/>
+    <circle cx="70" cy="133" r="8"/>
+    <circle cx="250" cy="133" r="8"/>
+  </g>
+  <text x="160" y="176" text-anchor="middle" fill="#ffffff" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700">SixthSense</text>
+  <text x="160" y="192" text-anchor="middle" fill="#bfeeff" font-family="Arial, Helvetica, sans-serif" font-size="12">Whole-Body Wrench Estimation</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,41 @@
 
 
 
+    <tr bgcolor="#ffffd0">
+      <td style="padding:16px;width:20%;vertical-align:middle">
+        <div class="one">
+          <img src='images/SixthSense2026.svg' width="160">
+        </div>
+      </td>
+      <td style="padding:8px;width:80%;vertical-align:middle">
+        <a href="https://arxiv.org/abs/2605.01427">
+          <span class="papertitle">SixthSense: Task-Agnostic Proprioception-Only Whole-Body Wrench Estimation for Humanoids</span>
+        </a>
+        <br>
+        Xingzhou Chen*,
+        Xiayan Xu*,
+        Yan Ning,
+        Ling Shi,
+        Jiyu Yu,
+        Yizheng Zhang,
+        Siyi Qian,
+        Lingzhu Xiang,
+        Jiahao Chen,
+        Yuquan Wang&dagger;,
+        <strong><a href="https://0aqz0.github.io/">Haodong Zhang</a></strong>&dagger;
+        <br>
+        <em>arXiv preprint arXiv:2605.01427</em>, 2026
+        <br>
+        <a href="https://arxiv.org/abs/2605.01427">arXiv</a>
+        <p></p>
+        <p>
+        SixthSense estimates whole-body contact timing, location, and external wrenches from proprioception and IMU data alone, enabling force-aware humanoid interaction without force, vision, or tactile sensors.
+        </p>
+      </td>
+    </tr>
+
+
+
     <!--
     <tr onmouseout="power_stop()" onmouseover="power_start()" bgcolor="#ffffd0">
       <td style="padding:16px;width:20%;vertical-align:middle">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add the SixthSense arXiv preprint to the homepage research list.
- Mark Yuquan Wang and Haodong Zhang as corresponding authors.
- Add a lightweight SVG thumbnail for the new paper entry.

## Testing
- `git diff --check HEAD~1..HEAD`
- Static Python check for the new title, arXiv link, corresponding-author markers, and thumbnail path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52d7d9df-c238-4763-9282-7edd75950fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52d7d9df-c238-4763-9282-7edd75950fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

